### PR TITLE
Add API endpoint that lists all promotions

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -74,6 +74,18 @@ def create_promotions():
         jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
     )
 
+######################################################################
+# LIST ALL THE PROMOTIONS
+######################################################################
+@app.route("/promotions/all", methods=["GET"])
+def list_promotions():
+    """
+    List all currently running promotions
+    This endpoint will return a Promotion based on it's id
+    """
+    app.logger.info("Request to list all current promotions")
+    all_promotions = Promotion.all()
+    return make_response(jsonify([promo.serialize() for promo in all_promotions]), status.HTTP_200_OK)    
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/service/service.py
+++ b/service/service.py
@@ -80,8 +80,7 @@ def create_promotions():
 @app.route("/promotions/all", methods=["GET"])
 def list_promotions():
     """
-    List all currently running promotions
-    This endpoint will return a Promotion based on it's id
+    List all promotions in the database
     """
     app.logger.info("Request to list all current promotions")
     all_promotions = Promotion.all()

--- a/service/service.py
+++ b/service/service.py
@@ -77,14 +77,16 @@ def create_promotions():
 ######################################################################
 # LIST ALL THE PROMOTIONS
 ######################################################################
-@app.route("/promotions/all", methods=["GET"])
+@app.route("/promotions", methods=["GET"])
 def list_promotions():
     """
-    List all promotions in the database
+    List all promotions
     """
-    app.logger.info("Request to list all current promotions")
+    app.logger.info("Request to list all promotions")
     all_promotions = Promotion.all()
-    return make_response(jsonify([promo.serialize() for promo in all_promotions]), status.HTTP_200_OK)    
+    results = [promo.serialize() for promo in all_promotions]
+    app.logger.info("Returning %d promotions", len(results))
+    return make_response(jsonify(results), status.HTTP_200_OK)
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -127,7 +127,7 @@ class TestPromotionService(TestCase):
         test_promotion01 = self._create_promotions(1)[0]
         
         # if it gets 200 status, we pass
-        resp = self.app.get("/promotions/all")
+        resp = self.app.get("/promotions")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         
         # check that the ID of test promos match JSON returned

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -117,8 +117,24 @@ class TestPromotionService(TestCase):
         """ Get a Promotion thats not found """
         resp = self.app.get("/promotions/0")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-
-
+            
+    
+    def test_list_promotion(self):
+        """ List all promotions in the database """
+        
+        # create two promotions
+        test_promotion00 = self._create_promotions(1)[0]
+        test_promotion01 = self._create_promotions(1)[0]
+        
+        # if it gets 200 status, we pass
+        resp = self.app.get("/promotions/all")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        # check that the ID of test promos match JSON returned
+        data = resp.get_json()
+        self.assertEqual(data[0]['id'], test_promotion00.id)
+        self.assertEqual(data[1]['id'], test_promotion01.id)
+    
 ######################################################################
 #   M A I N
 ######################################################################


### PR DESCRIPTION
This pull request adds the  endpoint to list all promotions in the database at `promotions/all` and also adds a test that makes sure that the link 200's and that the listed promotions actually exist and match promotions in the DB.

I am not very confident about the test that I wrote, it's probably very inelegant in any event. Would welcome input especially on that but obviously overall as well!