### PR TITLE
Fix cancel endpoint

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -206,7 +206,7 @@ def delete_promotions(promotion_id):
 ######################################################################
 # CANCEL A PROMOTION
 ######################################################################
-@app.route("/promotions/cancel/<int:promotion_id>", methods=["POST"])
+@app.route("/promotions/<int:promotion_id>/cancel", methods=["POST"])
 def cancel_promotions(promotion_id):
     """
     Cancel a Promotions

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -276,14 +276,14 @@ class TestPromotionService(TestCase):
         """ Cancel a promotion """
         
         # try to cancel it before it's in there
-        resp = self.app.post('/promotions/cancel/{}'.format(1), content_type='application/json')
+        resp = self.app.post('/promotions/{}/cancel'.format(1), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
         
         # create a new promotion
         test_promotion = self._create_promotions(1)[0]
         
         # cancel the promotion
-        resp = self.app.post('/promotions/cancel/{}'.format(test_promotion.id), content_type='application/json')
+        resp = self.app.post('/promotions/{}/cancel'.format(test_promotion.id), content_type='application/json')
                 
         # if it gets 200 status, we pass
         self.assertEqual(resp.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
The professor left some feedback on our first homework assignment that our `cancel` endpoint should have the ID first and then the action (`cancel`). This PR fixes that.