### PR TITLE
Serialize & deserialize products with promotions

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -187,6 +187,13 @@ class Promotion(db.Model):
             self.start_date = data["start_date"]
             self.end_date = data["end_date"]
             self.is_site_wide = data["is_site_wide"]
+            self.products = []
+            for product_id in data["products"]:
+                product = Product.query.get(product_id)
+                if product is None:
+                    raise DataValidationError("Promotion has a product with an ID that does not exist")
+                else:
+                    self.products.append(product)
         except KeyError as error:
             raise DataValidationError("Invalid promotion: missing " + error.args[0])
         except TypeError as error:

--- a/service/models.py
+++ b/service/models.py
@@ -167,7 +167,8 @@ class Promotion(db.Model):
             "amount": self.amount,
             "start_date": self.start_date.isoformat(),
             "end_date": self.end_date.isoformat(),
-            "is_site_wide": self.is_site_wide
+            "is_site_wide": self.is_site_wide,
+            "products": [product.id for product in self.products],
         }
 
     def deserialize(self, data):

--- a/service/service.py
+++ b/service/service.py
@@ -21,6 +21,7 @@ from service.models import Promotion, DataValidationError
 # Import Flask application
 from . import app
 
+
 ######################################################################
 # Error Handlers
 ######################################################################
@@ -29,9 +30,10 @@ def request_validation_error(error):
     """ Handles Value Errors from bad data """
     return bad_request(error)
 
+
 @app.errorhandler(status.HTTP_400_BAD_REQUEST)
 def bad_request(error):
-    """ Handles bad reuests with 400_BAD_REQUEST """
+    """ Handles bad requests with 400_BAD_REQUEST """
     app.logger.warning(str(error))
     return (
         jsonify(
@@ -39,6 +41,7 @@ def bad_request(error):
         ),
         status.HTTP_400_BAD_REQUEST,
     )
+
 
 @app.errorhandler(status.HTTP_404_NOT_FOUND)
 def not_found(error):
@@ -51,9 +54,10 @@ def not_found(error):
         status.HTTP_404_NOT_FOUND,
     )
 
+
 @app.errorhandler(status.HTTP_405_METHOD_NOT_ALLOWED)
 def method_not_supported(error):
-    """ Handles unsuppoted HTTP methods with 405_METHOD_NOT_SUPPORTED """
+    """ Handles unsupported HTTP methods with 405_METHOD_NOT_SUPPORTED """
     app.logger.warning(str(error))
     return (
         jsonify(
@@ -64,9 +68,10 @@ def method_not_supported(error):
         status.HTTP_405_METHOD_NOT_ALLOWED,
     )
 
+
 @app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 def mediatype_not_supported(error):
-    """ Handles unsuppoted media requests with 415_UNSUPPORTED_MEDIA_TYPE """
+    """ Handles unsupported media requests with 415_UNSUPPORTED_MEDIA_TYPE """
     app.logger.warning(str(error))
     return (
         jsonify(
@@ -76,6 +81,7 @@ def mediatype_not_supported(error):
         ),
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     )
+
 
 @app.errorhandler(status.HTTP_500_INTERNAL_SERVER_ERROR)
 def internal_server_error(error):
@@ -89,6 +95,7 @@ def internal_server_error(error):
         ),
         status.HTTP_500_INTERNAL_SERVER_ERROR,
     )
+
 
 ######################################################################
 # GET INDEX
@@ -154,7 +161,7 @@ def list_promotions():
     """
     app.logger.info("Request to list all promotions")
     filters = ['is_site_wide', 'promo_code', 'promo_type', 'amount',
-                'start_date', 'end_date', 'duration']
+               'start_date', 'end_date', 'duration']
     app.logger.info(request.args)
     if any(i in request.args for i in filters):
         promotions = Promotion.find_by_query_string(request.args)
@@ -203,6 +210,7 @@ def delete_promotions(promotion_id):
     app.logger.info("Promotion with ID [%s] delete complete.", promotion_id)
     return make_response("", status.HTTP_204_NO_CONTENT)
 
+
 ######################################################################
 # CANCEL A PROMOTION
 ######################################################################
@@ -221,6 +229,7 @@ def cancel_promotions(promotion_id):
     app.logger.info("Promotion with ID [%s] cancelled", promotion_id)
     return make_response("", status.HTTP_200_OK)
 
+
 ######################################################################
 # APPLY BEST PROMOTION
 ######################################################################
@@ -234,19 +243,20 @@ def apply_best_promotions():
     if len(request.args) > 0:
         results = [
             Promotion.apply_best_promo(product) \
-                for product in request.args
+            for product in request.args
         ]
-        results = list(filter(None, results))    
+        results = list(filter(None, results))
     else:
         results = []
     app.logger.info("Returning %d results.", len(results))
     return make_response(jsonify(results), status.HTTP_200_OK)
 
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 def init_db():
-    """ Initialies the SQLAlchemy app """
+    """ Initializes the SQLAlchemy app """
     global app
     Promotion.init_db(app)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -178,6 +178,45 @@ class TestPromotion(unittest.TestCase):
             },
         )
 
+    def test_deserialize(self):
+        """ Test deserialization of a promotion """
+        promotion = Promotion(
+            id=2,
+            title="Thanksgiving Special",
+            description="Some items off in honor of the most grateful month.",
+            promo_code="tgiving",
+            promo_type=PromoType.DISCOUNT,
+            amount=50,
+            start_date=datetime(2020, 11, 1),
+            end_date=datetime(2020, 11, 30),
+            is_site_wide=False,
+        )
+        product_1 = Product()
+        product_1.id = 123
+        promotion.products.append(product_1)
+        product_2 = Product()
+        product_2.id = 456
+        promotion.products.append(product_2)
+        db.session.add(product_1)
+        db.session.add(product_2)
+
+        data = promotion.serialize()
+        promotion.deserialize(data)
+
+        self.assertNotEqual(promotion, None)
+        self.assertEqual(promotion.id, 2)
+        self.assertEqual(promotion.title, "Thanksgiving Special")
+        self.assertEqual(promotion.description, "Some items off in honor of the most grateful month.")
+        self.assertEqual(promotion.promo_code, "tgiving")
+        self.assertEqual(promotion.amount, 50)
+        self.assertEqual(promotion.start_date, "2020-11-01T00:00:00")
+        self.assertEqual(promotion.end_date, "2020-11-30T00:00:00")
+        self.assertEqual(promotion.is_site_wide, False)
+        self.assertEqual(
+            [product.id for product in promotion.products],
+            [123, 456],
+        )
+
     def test_deserialize_missing_data(self):
         """ Test deserialization of a Promotion with missing data """
         data = {"id": 1, "name": "kitty", "category": "cat"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,9 @@ import logging
 import unittest
 import os
 from werkzeug.exceptions import NotFound
-from service.models import Promotion, DataValidationError, db, PromoType
+from service.models import Promotion, Product, DataValidationError, db, PromoType
 from service import app
+from datetime import datetime
 from .factories import PromotionFactory
 from datetime import datetime
 
@@ -141,15 +142,50 @@ class TestPromotion(unittest.TestCase):
     def test_test(self):
         """ Test if the test environment works """
         self.assertTrue(True)
+        
+    def test_serialize(self):
+        """ Test serialization of a Promotion """
+        promotion = Promotion(
+            id=1,
+            title="Halloween Special",
+            description="Some items off in honor of the spookiest month.",
+            promo_code="hween",
+            promo_type=PromoType.DISCOUNT,
+            amount=25,
+            start_date=datetime(2020, 10, 20),
+            end_date=datetime(2020, 11, 1),
+            is_site_wide=True,
+        )
+        product_1 = Product()
+        product_1.id = 123
+        promotion.products.append(product_1)
+        product_2 = Product()
+        product_2.id = 456
+        promotion.products.append(product_2)
+        self.assertEqual(
+            promotion.serialize(),
+            {
+                "id": 1,
+                "title": "Halloween Special",
+                "description": "Some items off in honor of the spookiest month.",
+                "promo_code": "hween",
+                "promo_type": "DISCOUNT",
+                "amount": 25,
+                "start_date": "2020-10-20T00:00:00",
+                "end_date": "2020-11-01T00:00:00",
+                "is_site_wide": True,
+                "products": [123, 456],
+            },
+        )
 
     def test_deserialize_missing_data(self):
-        """ Test deserialization of a Promotion """
+        """ Test deserialization of a Promotion with missing data """
         data = {"id": 1, "name": "kitty", "category": "cat"}
         promotion = Promotion()
         self.assertRaises(DataValidationError, promotion.deserialize, data)
 
     def test_deserialize_bad_data(self):
-        """ Test deserialization of bad data """
+        """ Test deserialization of a Promotion with bad data """
         data = "this is not a dictionary"
         promotion = Promotion()
         self.assertRaises(DataValidationError, promotion.deserialize, data)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -345,8 +345,8 @@ class TestPromotionService(TestCase):
             }
         ]
         tests = [
-            (f"123=1000&456=5000", []),
-            (f"123=1000&456=5000", [{'123':'promo_code_3'}, {'456': 'promo_code_3'}]),
+            ("123=1000&456=5000", []),
+            ("123=1000&456=5000", [{'123':'promo_code_3'}, {'456': 'promo_code_3'}]),
             ('', [])
         ]
         # Carry out the tests without promotions in the system
@@ -366,8 +366,6 @@ class TestPromotionService(TestCase):
             if promo['promo_code'] == 'promo_code_1':
                 test_promotion.products.append(product_1)
                 test_promotion.products.append(product_2)
-            elif promo['promo_code'] == 'promo_code_3':
-                test_promotion.products.append(product_1)
             elif promo['promo_code'] == 'promo_code_4':
                 test_promotion.products.append(product_2)
             resp = self.app.post(


### PR DESCRIPTION
This PR adds support for serializing and deserializing products with promotions. I added a test that covers this and got 96% coverage. I also did some minor formatting for PEP8 style. 

Our tests assume that we are doing serialization and de-serialization, so I did them in one PR. I can't figure out how to link both issues in the one PR, but we can probably just move them to close when this is merged.