### PR TITLE
Additional query parameters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pinocchio==0.4.2
 factory-boy==2.12.0
 pylint>=2.4.1
 httpie>=1.0.3
+freezegun==1.0.0
 
 # Code coverage
 coverage==4.5.4

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -11,7 +11,7 @@ from flask import Flask
 
 # Create Flask application
 app = Flask(__name__)
-app.config.from_object('config')
+app.config.from_object("config")
 
 # pylint: disable=wrong-import-position
 # Import the routes After the Flask app is created

--- a/service/models.py
+++ b/service/models.py
@@ -141,8 +141,10 @@ class Promotion(db.Model):
         if 'active' in args:
             if args.get('active') == '1':
                 data = data.filter(cls.start_date <= datetime.now()).filter(cls.end_date >= datetime.now())
-            else:
+            if args.get('active') == '0':
                 data = data.filter((cls.start_date > datetime.now()) | (datetime.now() > cls.end_date))
+        if 'product' in args:
+            data = data.filter(cls.products.any(id=args.get('product')))
         return data.all()
 
     @classmethod

--- a/service/models.py
+++ b/service/models.py
@@ -80,8 +80,7 @@ class Promotion(db.Model):
     end_date = db.Column(db.DateTime(), nullable=False)
     is_site_wide = db.Column(db.Boolean(), nullable=False, default=False)
     # for promotion_products Many-to-Many relationship
-    products = db.relationship('Product', secondary=promotion_products, lazy='subquery',
-                               backref=db.backref('promotions', lazy=True))
+    products = db.relationship('Product', secondary=promotion_products, lazy='subquery')
 
     def __repr__(self):
         return "<Promotion %r id=[%s]>" % (self.title, self.id)
@@ -144,10 +143,7 @@ class Promotion(db.Model):
             if args.get('active') == '0':
                 data = data.filter((cls.start_date > datetime.now()) | (datetime.now() > cls.end_date))
         if 'product' in args:
-            # data = data.join(Product).filter(Product.id=int(args.get('product')))
             data = data.filter(cls.products.any(id=int(args.get('product'))))
-            # print("erergearsg: ", args.get('product'), data)
-        # print("data: ", data.all())
         return data.all()
 
     @classmethod

--- a/service/models.py
+++ b/service/models.py
@@ -26,8 +26,8 @@ promotion_products - The relationship between promotion and product
 """
 import logging
 from enum import Enum
-from flask_sqlalchemy import SQLAlchemy
 from datetime import timedelta, datetime
+from flask_sqlalchemy import SQLAlchemy
 import dateutil.parser
 
 logger = logging.getLogger("flask.app")
@@ -38,8 +38,6 @@ db = SQLAlchemy()
 
 class DataValidationError(Exception):
     """ Used for an data validation errors when deserializing """
-    pass
-
 
 class PromoType(Enum):
     """ Enumeration of valid promotion types"""
@@ -80,7 +78,7 @@ class Promotion(db.Model):
     end_date = db.Column(db.DateTime(), nullable=False)
     is_site_wide = db.Column(db.Boolean(), nullable=False, default=False)
     # for promotion_products Many-to-Many relationship
-    products = db.relationship('Product', secondary=promotion_products, lazy='subquery')
+    products = db.relationship("Product", secondary=promotion_products, lazy="subquery")
 
     def __repr__(self):
         return "<Promotion %r id=[%s]>" % (self.title, self.id)
@@ -126,34 +124,45 @@ class Promotion(db.Model):
         """ Find a Promotion by query string """
         logger.info(" Processing lookup based on query string %s ...", args)
         filters = {}
-        for f in ['is_site_wide', 'promo_code', 'amount', 'promo_type']:
+        for f in ["is_site_wide", "promo_code", "amount", "promo_type"]:
             if f in args:
                 filters[f] = args.get(f)
         data = cls.query.filter_by(**filters) if filters else cls.query
-        if 'start_date' in args:
-            data = data.filter(cls.start_date >= dateutil.parser.parse(args['start_date']))
-        if 'end_date' in args:
-            data = data.filter(cls.end_date <= dateutil.parser.parse(args['end_date']))
-        if 'duration' in args:
+        if "start_date" in args:
+            data = data.filter(
+                cls.start_date >= dateutil.parser.parse(args["start_date"])
+            )
+        if "end_date" in args:
+            data = data.filter(cls.end_date <= dateutil.parser.parse(args["end_date"]))
+        if "duration" in args:
             # returns promotions that last at least the number of days specified
-            data = data.filter(cls.start_date + timedelta(days=int(args.get('duration'))) >= cls.end_date)
-        if 'active' in args:
-            if args.get('active') == '1':
-                data = data.filter(cls.start_date <= datetime.now()).filter(cls.end_date >= datetime.now())
-            if args.get('active') == '0':
-                data = data.filter((cls.start_date > datetime.now()) | (datetime.now() > cls.end_date))
-        if 'product' in args:
-            data = data.filter(cls.products.any(id=int(args.get('product'))))
+            data = data.filter(
+                cls.start_date + timedelta(days=int(args.get("duration")))
+                >= cls.end_date
+            )
+        if "active" in args:
+            if args.get("active") == "1":
+                data = data.filter(cls.start_date <= datetime.now()).filter(
+                    cls.end_date >= datetime.now()
+                )
+            if args.get("active") == "0":
+                data = data.filter(
+                    (cls.start_date > datetime.now()) | (datetime.now() > cls.end_date)
+                )
+        if "product" in args:
+            data = data.filter(cls.products.any(id=int(args.get("product"))))
         return data.all()
 
     @classmethod
     def apply_best_promo(cls, product_id, pricing):
         """ Find a Promotion by query string """
         logger.info(" Finding best promotion for the product %s ...", product_id)
-        promos = cls.query.filter(cls.start_date <= datetime.now()).filter(cls.end_date >= datetime.now())
+        promos = cls.query.filter(cls.start_date <= datetime.now()).filter(
+            cls.end_date >= datetime.now()
+        )
 
-        product_promos = promos.filter(cls.products.any(id = product_id))
-        site_wide_promos = promos.filter(cls.is_site_wide == True)
+        product_promos = promos.filter(cls.products.any(id=product_id))
+        site_wide_promos = promos.filter(cls.is_site_wide)
         logger.info("  Available site wide promos: " + str(site_wide_promos.all()))
         logger.info("  Available promos for this product: " + str(product_promos.all()))
 
@@ -163,13 +172,16 @@ class Promotion(db.Model):
                 if p.amount > best_discount:
                     best_promo, best_discount = p, p.amount
             elif p.promo_type == PromoType.BOGO and best_discount < 50:
-                    best_promo, best_discount = p, 50
+                best_promo, best_discount = p, 50
             elif p.promo_type == PromoType.FIXED:
-                fixed_discount = (((pricing - p.amount)/ pricing) * 100)
+                fixed_discount = ((pricing - p.amount) / pricing) * 100
                 if fixed_discount > best_discount:
                     best_promo, best_discount = p, fixed_discount
 
-        logger.info("  Promotion selected: " + str(best_promo.promo_code if best_promo else None))
+        logger.info(
+            "  Promotion selected: "
+            + str(best_promo.promo_code if best_promo else None)
+        )
         return {product_id: best_promo.promo_code} if best_promo else None
 
     def serialize(self):
@@ -198,7 +210,9 @@ class Promotion(db.Model):
             self.title = data["title"]
             self.description = data["description"]
             self.promo_code = data["promo_code"]
-            self.promo_type = getattr(PromoType, data['promo_type'])  # create enum from string
+            self.promo_type = getattr(
+                PromoType, data["promo_type"]
+            )  # create enum from string
             self.amount = data["amount"]
             self.start_date = data["start_date"]
             self.end_date = data["end_date"]
@@ -207,7 +221,9 @@ class Promotion(db.Model):
             for product_id in data["products"]:
                 product = Product.query.get(product_id)
                 if product is None:
-                    raise DataValidationError("Promotion has a product with an ID that does not exist")
+                    raise DataValidationError(
+                        "Promotion has a product with an ID that does not exist"
+                    )
                 else:
                     self.products.append(product)
         except KeyError as error:

--- a/service/models.py
+++ b/service/models.py
@@ -144,7 +144,10 @@ class Promotion(db.Model):
             if args.get('active') == '0':
                 data = data.filter((cls.start_date > datetime.now()) | (datetime.now() > cls.end_date))
         if 'product' in args:
-            data = data.filter(cls.products.any(id=args.get('product')))
+            # data = data.join(Product).filter(Product.id=int(args.get('product')))
+            data = data.filter(cls.products.any(id=int(args.get('product'))))
+            # print("erergearsg: ", args.get('product'), data)
+        # print("data: ", data.all())
         return data.all()
 
     @classmethod

--- a/service/service.py
+++ b/service/service.py
@@ -160,8 +160,17 @@ def list_promotions():
     List all promotions
     """
     app.logger.info("Request to list all promotions")
-    filters = ['is_site_wide', 'promo_code', 'promo_type', 'amount',
-               'start_date', 'end_date', 'duration', 'active', 'product']
+    filters = [
+        "is_site_wide",
+        "promo_code",
+        "promo_type",
+        "amount",
+        "start_date",
+        "end_date",
+        "duration",
+        "active",
+        "product",
+    ]
     app.logger.info(request.args)
     if any(i in request.args for i in filters):
         promotions = Promotion.find_by_query_string(request.args)
@@ -242,7 +251,7 @@ def apply_best_promotions():
     app.logger.info(request.args)
     if len(request.args) > 0:
         results = [
-            Promotion.apply_best_promo(product, int(request.args.get(product))) \
+            Promotion.apply_best_promo(product, int(request.args.get(product)))
             for product in request.args
         ]
         results = list(filter(None, results))

--- a/service/service.py
+++ b/service/service.py
@@ -161,7 +161,7 @@ def list_promotions():
     """
     app.logger.info("Request to list all promotions")
     filters = ['is_site_wide', 'promo_code', 'promo_type', 'amount',
-               'start_date', 'end_date', 'duration']
+               'start_date', 'end_date', 'duration', 'active']
     app.logger.info(request.args)
     if any(i in request.args for i in filters):
         promotions = Promotion.find_by_query_string(request.args)

--- a/service/service.py
+++ b/service/service.py
@@ -161,7 +161,7 @@ def list_promotions():
     """
     app.logger.info("Request to list all promotions")
     filters = ['is_site_wide', 'promo_code', 'promo_type', 'amount',
-               'start_date', 'end_date', 'duration', 'active']
+               'start_date', 'end_date', 'duration', 'active', 'product']
     app.logger.info(request.args)
     if any(i in request.args for i in filters):
         promotions = Promotion.find_by_query_string(request.args)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,4 +22,3 @@ class PromotionFactory(factory.Factory):
     start_date = datetime(2020, 10, 17)
     end_date = datetime(2020, 10, 18)
     is_site_wide = True
-    products = []

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,3 +22,4 @@ class PromotionFactory(factory.Factory):
     start_date = datetime(2020, 10, 17)
     end_date = datetime(2020, 10, 18)
     is_site_wide = True
+    products = []

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,10 +1,10 @@
 """
 Test Factory to make fake objects for testing
 """
+from datetime import datetime
 import factory
 from factory.fuzzy import FuzzyChoice
-from service.models import Promotion, Product, PromoType
-from datetime import datetime
+from service.models import Promotion, PromoType
 
 
 class PromotionFactory(factory.Factory):
@@ -13,11 +13,13 @@ class PromotionFactory(factory.Factory):
     class Meta:
         model = Promotion
 
-    id = factory.Sequence(lambda n: n*100)
+    id = factory.Sequence(lambda n: n * 100)
     title = "title"
     description = "description"
     promo_code = "promo_code"
-    promo_type = FuzzyChoice(choices=[PromoType.BOGO, PromoType.DISCOUNT, PromoType.FIXED])
+    promo_type = FuzzyChoice(
+        choices=[PromoType.BOGO, PromoType.DISCOUNT, PromoType.FIXED]
+    )
     amount = 10
     start_date = datetime(2020, 10, 17)
     end_date = datetime(2020, 10, 18)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,12 +8,11 @@ Test cases can be run with:
 import logging
 import unittest
 import os
+from datetime import datetime
 from werkzeug.exceptions import NotFound
 from service.models import Promotion, Product, DataValidationError, db, PromoType
 from service import app
-from datetime import datetime
 from .factories import PromotionFactory
-from datetime import datetime
 
 
 DATABASE_URI = os.getenv(
@@ -29,8 +28,8 @@ class TestPromotion(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        app.config['TESTING'] = True
-        app.config['DEBUG'] = False
+        app.config["TESTING"] = True
+        app.config["DEBUG"] = False
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         Promotion.init_db(app)
@@ -38,7 +37,6 @@ class TestPromotion(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """ This runs once after the entire test suite """
-        pass
 
     def setUp(self):
         db.drop_all()  # clean up the last tests
@@ -60,7 +58,8 @@ class TestPromotion(unittest.TestCase):
             amount=10,
             start_date=datetime(2020, 10, 17),
             end_date=datetime(2020, 10, 18),
-            is_site_wide=True)
+            is_site_wide=True,
+        )
         self.assertTrue(promotion is not None)
         self.assertEqual(promotion.id, None)
         self.assertEqual(promotion.title, "test_create")
@@ -80,8 +79,9 @@ class TestPromotion(unittest.TestCase):
             amount=10,
             start_date=datetime(2020, 10, 17),
             end_date=datetime(2020, 10, 18),
-            is_site_wide=True)
-        self.assertTrue(promotion != None)
+            is_site_wide=True,
+        )
+        self.assertTrue(promotion is not None)
         self.assertEqual(promotion.id, None)
         promotion.create()
         # Assert that it was assigned an id and shows up in the database
@@ -97,7 +97,8 @@ class TestPromotion(unittest.TestCase):
             amount=10,
             start_date=datetime(2020, 10, 17),
             end_date=datetime(2020, 10, 18),
-            is_site_wide=True)
+            is_site_wide=True,
+        )
         promotion.create()
         self.assertEqual(promotion.id, 1)
         # Change it and update it
@@ -117,7 +118,8 @@ class TestPromotion(unittest.TestCase):
             amount=10,
             start_date=datetime(2020, 10, 17),
             end_date=datetime(2020, 10, 18),
-            is_site_wide=True)
+            is_site_wide=True,
+        )
         try:
             promotion.update()
         except:
@@ -131,7 +133,7 @@ class TestPromotion(unittest.TestCase):
             amount=10,
             start_date=datetime(2020, 10, 17),
             end_date=datetime(2020, 10, 18),
-            is_site_wide=True
+            is_site_wide=True,
         )
         promotion.create()
         self.assertEqual(len(Promotion.all()), 1)
@@ -142,7 +144,7 @@ class TestPromotion(unittest.TestCase):
     def test_test(self):
         """ Test if the test environment works """
         self.assertTrue(True)
-        
+
     def test_serialize(self):
         """ Test serialization of a Promotion """
         promotion = Promotion(
@@ -206,7 +208,9 @@ class TestPromotion(unittest.TestCase):
         self.assertNotEqual(promotion, None)
         self.assertEqual(promotion.id, 2)
         self.assertEqual(promotion.title, "Thanksgiving Special")
-        self.assertEqual(promotion.description, "Some items off in honor of the most grateful month.")
+        self.assertEqual(
+            promotion.description, "Some items off in honor of the most grateful month."
+        )
         self.assertEqual(promotion.promo_code, "tgiving")
         self.assertEqual(promotion.amount, 50)
         self.assertEqual(promotion.start_date, "2020-11-01T00:00:00")
@@ -251,6 +255,7 @@ class TestPromotion(unittest.TestCase):
     def test_find_or_404_not_found(self):
         """ Find or return 404 NOT found """
         self.assertRaises(NotFound, Promotion.find_or_404, 0)
+
 
 ######################################################################
 #   M A I N

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -219,6 +219,7 @@ class TestPromotionService(TestCase):
         # Define the test cases
         test_cases = [
             {
+                "title":"0",
                 "promo_code": "XYZ0000",
                 "promo_type": PromoType.DISCOUNT,
                 "amount": 50,
@@ -226,7 +227,8 @@ class TestPromotionService(TestCase):
                 "start_date": datetime(2020, 10, 17),
                 "end_date": datetime(2020, 10, 21),
             },
-            { 
+            {
+                "title": "1",
                 "promo_code": "XYZ0001",
                 "promo_type": PromoType.DISCOUNT,
                 "amount": 10,
@@ -234,7 +236,8 @@ class TestPromotionService(TestCase):
                 "start_date": datetime(2020, 10, 21),
                 "end_date": datetime(2020, 10, 23),
             },
-            { 
+            {
+                "title": "2",
                 "promo_code": "XYZ0002",
                 "promo_type": PromoType.BOGO,
                 "amount": 2,
@@ -242,7 +245,8 @@ class TestPromotionService(TestCase):
                 "start_date": datetime(2020, 10, 14),
                 "end_date": datetime(2020, 10, 18),
             },
-            { 
+            {
+                "title": "3",
                 "promo_code": "XYZ0003",
                 "promo_type": PromoType.DISCOUNT,
                 "amount": 20,
@@ -252,28 +256,30 @@ class TestPromotionService(TestCase):
             }
         ]
         tests = [
-            # ("is_site_wide=true", 1),
-            # ("is_site_wide=false", 3),
-            # ("promo_code=XYZ0004", 0),
-            # ("promo_code=XYZ0003", 1),
-            # ("promo_code=XYZ0003&is_site_wide=false", 1),
-            # ("amount=20&is_site_wide=false", 1),
-            # ("amount=20&is_site_wide=true", 0),
-            # ("promo_type=DISCOUNT&is_site_wide=true", 1),
-            # ("promo_type=BOGO", 1),
-            # ("start_date=Sat, 17 Oct 2020 00:00:00 GMT", 2),
-            # ("start_date=Tue, 14 Oct 2020 00:00:00 GMT&end_date=Wed, 18 Oct 2020 00:00:00 GMT", 1),
-            # ("duration=4", 3),
-            # ("active=0", 3),
-            # ("active=1", 1),
+            ("is_site_wide=true", 1),
+            ("is_site_wide=false", 3),
+            ("promo_code=XYZ0004", 0),
+            ("promo_code=XYZ0003", 1),
+            ("promo_code=XYZ0003&is_site_wide=false", 1),
+            ("amount=20&is_site_wide=false", 1),
+            ("amount=20&is_site_wide=true", 0),
+            ("promo_type=DISCOUNT&is_site_wide=true", 1),
+            ("promo_type=BOGO", 1),
+            ("start_date=Sat, 17 Oct 2020 00:00:00 GMT", 2),
+            ("start_date=Tue, 14 Oct 2020 00:00:00 GMT&end_date=Wed, 18 Oct 2020 00:00:00 GMT", 1),
+            ("duration=4", 3),
+            ("active=0", 3),
+            ("active=1", 1),
             ("product=100", 3)
         ]
         # Create the set of Promotions
         for test_case in test_cases:
+            logging.debug("promotion factory call")
             test_promotion = PromotionFactory()
             for attribute in test_case:
                 setattr(test_promotion, attribute, test_case[attribute])
-            if test_case['is_site_wide'] == "false":
+            if test_case['is_site_wide'] == False:
+                logging.debug(test_case)
                 test_promotion.products.append(product_1)
 
             resp = self.app.post(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16,6 +16,8 @@ from service import app
 from service.service import init_db
 from .factories import PromotionFactory
 from datetime import datetime
+from freezegun import freeze_time
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgres://postgres:postgres@localhost:5432/postgres"
@@ -25,6 +27,7 @@ DATABASE_URI = os.getenv(
 ######################################################################
 #  T E S T   C A S E S
 ######################################################################
+@freeze_time("2020-11-03")
 class TestPromotionService(TestCase):
     """ REST API Server Tests """
 
@@ -231,8 +234,8 @@ class TestPromotionService(TestCase):
                 "promo_type": PromoType.BOGO,
                 "amount": 2,
                 "is_site_wide": False,
-                "start_date": datetime(2020, 10, 16),
-                "end_date": datetime(2020, 10, 23),
+                "start_date": datetime(2020, 10, 14),
+                "end_date": datetime(2020, 10, 18),
             },
             { 
                 "promo_code": "XYZ0003",
@@ -240,7 +243,7 @@ class TestPromotionService(TestCase):
                 "amount": 20,
                 "is_site_wide": False,
                 "start_date": datetime(2020, 10, 14),
-                "end_date": datetime(2020, 10, 18),
+                "end_date": datetime(2021, 10, 18),
             }
         ]
         tests = [
@@ -254,8 +257,10 @@ class TestPromotionService(TestCase):
             ("promo_type=DISCOUNT&is_site_wide=true", 1),
             ("promo_type=BOGO", 1),
             ("start_date=Sat, 17 Oct 2020 00:00:00 GMT", 2),
-            ("start_date=Tue, 13 Oct 2020 00:00:00 GMT&end_date=Wed, 21 Oct 2020 00:00:00 GMT", 2),
-            ("duration=4", 3)
+            ("start_date=Tue, 14 Oct 2020 00:00:00 GMT&end_date=Wed, 18 Oct 2020 00:00:00 GMT", 1),
+            ("duration=4", 3),
+            ("active=0", 3),
+            ("active=1", 1)
         ]
         # Create the set of Promotions
         for test_case in test_cases:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -261,7 +261,9 @@ class TestPromotionService(TestCase):
         ]
         tests = [
             ("is_site_wide=true", 1),
+            ("is_site_wide=true&product=100", 0),
             ("is_site_wide=false", 3),
+            ("is_site_wide=false&product=200", 1),
             ("promo_code=XYZ0004", 0),
             ("promo_code=XYZ0003", 1),
             ("promo_code=XYZ0003&is_site_wide=false", 1),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -211,6 +211,11 @@ class TestPromotionService(TestCase):
 
     def test_query_promotion(self):
         """ Query all promotions in the database by multiple parameters """
+        product_1 = Product()
+        product_1.id = 100
+
+        db.session.add(product_1)
+
         # Define the test cases
         test_cases = [
             {
@@ -247,26 +252,30 @@ class TestPromotionService(TestCase):
             }
         ]
         tests = [
-            ("is_site_wide=true", 1),
-            ("is_site_wide=false", 3),
-            ("promo_code=XYZ0004", 0),
-            ("promo_code=XYZ0003", 1),
-            ("promo_code=XYZ0003&is_site_wide=false", 1),
-            ("amount=20&is_site_wide=false", 1),
-            ("amount=20&is_site_wide=true", 0),
-            ("promo_type=DISCOUNT&is_site_wide=true", 1),
-            ("promo_type=BOGO", 1),
-            ("start_date=Sat, 17 Oct 2020 00:00:00 GMT", 2),
-            ("start_date=Tue, 14 Oct 2020 00:00:00 GMT&end_date=Wed, 18 Oct 2020 00:00:00 GMT", 1),
-            ("duration=4", 3),
-            ("active=0", 3),
-            ("active=1", 1)
+            # ("is_site_wide=true", 1),
+            # ("is_site_wide=false", 3),
+            # ("promo_code=XYZ0004", 0),
+            # ("promo_code=XYZ0003", 1),
+            # ("promo_code=XYZ0003&is_site_wide=false", 1),
+            # ("amount=20&is_site_wide=false", 1),
+            # ("amount=20&is_site_wide=true", 0),
+            # ("promo_type=DISCOUNT&is_site_wide=true", 1),
+            # ("promo_type=BOGO", 1),
+            # ("start_date=Sat, 17 Oct 2020 00:00:00 GMT", 2),
+            # ("start_date=Tue, 14 Oct 2020 00:00:00 GMT&end_date=Wed, 18 Oct 2020 00:00:00 GMT", 1),
+            # ("duration=4", 3),
+            # ("active=0", 3),
+            # ("active=1", 1),
+            ("product=100", 3)
         ]
         # Create the set of Promotions
         for test_case in test_cases:
             test_promotion = PromotionFactory()
             for attribute in test_case:
                 setattr(test_promotion, attribute, test_case[attribute])
+            if test_case['is_site_wide'] == "false":
+                test_promotion.products.append(product_1)
+
             resp = self.app.post(
                 "/promotions", json=test_promotion.serialize(), content_type="application/json"
             )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,14 +8,13 @@ Test cases can be run with the following:
 import os
 import logging
 import unittest
+from datetime import datetime
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 from flask_api import status  # HTTP Status Codes
 from service.models import Promotion, DataValidationError, db, PromoType, Product
 from service import app
 from service.service import init_db
 from .factories import PromotionFactory
-from datetime import datetime
 from freezegun import freeze_time
 
 
@@ -34,8 +33,8 @@ class TestPromotionService(TestCase):
     @classmethod
     def setUpClass(cls):
         """ Run once before all tests """
-        app.config['TESTING'] = True
-        app.config['DEBUG'] = False
+        app.config["TESTING"] = True
+        app.config["DEBUG"] = False
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         init_db()
@@ -60,10 +59,14 @@ class TestPromotionService(TestCase):
         for _ in range(count):
             test_promotion = PromotionFactory()
             resp = self.app.post(
-                "/promotions", json=test_promotion.serialize(), content_type="application/json"
+                "/promotions",
+                json=test_promotion.serialize(),
+                content_type="application/json",
             )
             self.assertEqual(
-                resp.status_code, status.HTTP_201_CREATED, "Could not create test promotion"
+                resp.status_code,
+                status.HTTP_201_CREATED,
+                "Could not create test promotion",
             )
             new_promotion = resp.get_json()
             test_promotion.id = new_promotion["id"]
@@ -84,27 +87,49 @@ class TestPromotionService(TestCase):
         test_promotion = PromotionFactory()
         logging.debug(test_promotion)
         resp = self.app.post(
-            "/promotions", json=test_promotion.serialize(), content_type="application/json"
+            "/promotions",
+            json=test_promotion.serialize(),
+            content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         # Check the data is correct
         new_promotion = resp.get_json()
-        self.assertEqual(new_promotion["title"], test_promotion.title,
-                         "Titles do not match")
-        self.assertEqual(new_promotion["description"], test_promotion.description,
-                         "Descriptions do not match")
-        self.assertEqual(new_promotion["promo_code"], test_promotion.promo_code,
-                         "Promo Codes do not match")
-        self.assertEqual(new_promotion["promo_type"], test_promotion.promo_type.name,
-                         "Promo Types do not match")
-        self.assertEqual(new_promotion["amount"], test_promotion.amount,
-                         "Amounts do not match")
-        self.assertEqual(new_promotion["start_date"], test_promotion.start_date.isoformat(),
-                         "Start Date does not match")
-        self.assertEqual(new_promotion["end_date"], test_promotion.end_date.isoformat(),
-                         "End Date does not match")
-        self.assertEqual(new_promotion["is_site_wide"], test_promotion.is_site_wide,
-                         "Is Site Wide bool does not match")
+        self.assertEqual(
+            new_promotion["title"], test_promotion.title, "Titles do not match"
+        )
+        self.assertEqual(
+            new_promotion["description"],
+            test_promotion.description,
+            "Descriptions do not match",
+        )
+        self.assertEqual(
+            new_promotion["promo_code"],
+            test_promotion.promo_code,
+            "Promo Codes do not match",
+        )
+        self.assertEqual(
+            new_promotion["promo_type"],
+            test_promotion.promo_type.name,
+            "Promo Types do not match",
+        )
+        self.assertEqual(
+            new_promotion["amount"], test_promotion.amount, "Amounts do not match"
+        )
+        self.assertEqual(
+            new_promotion["start_date"],
+            test_promotion.start_date.isoformat(),
+            "Start Date does not match",
+        )
+        self.assertEqual(
+            new_promotion["end_date"],
+            test_promotion.end_date.isoformat(),
+            "End Date does not match",
+        )
+        self.assertEqual(
+            new_promotion["is_site_wide"],
+            test_promotion.is_site_wide,
+            "Is Site Wide bool does not match",
+        )
 
     def test_get_promotion(self):
         """ Get a single Promotion """
@@ -135,15 +160,17 @@ class TestPromotionService(TestCase):
 
         # check that the ID of test promos match JSON returned
         data = resp.get_json()
-        self.assertEqual(data[0]['id'], test_promotion00.id)
-        self.assertEqual(data[1]['id'], test_promotion01.id)
+        self.assertEqual(data[0]["id"], test_promotion00.id)
+        self.assertEqual(data[1]["id"], test_promotion01.id)
 
     def test_update_promotion(self):
         """ Update an existing Promotion """
         # create a promotion to update
         test_promotion = PromotionFactory()
         resp = self.app.post(
-            "/promotions", json=test_promotion.serialize(), content_type="application/json"
+            "/promotions",
+            json=test_promotion.serialize(),
+            content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         # update the promotion
@@ -195,7 +222,9 @@ class TestPromotionService(TestCase):
             test_promotion = PromotionFactory()
             test_promotion.is_site_wide = site_wide
             resp = self.app.post(
-                "/promotions", json=test_promotion.serialize(), content_type="application/json"
+                "/promotions",
+                json=test_promotion.serialize(),
+                content_type="application/json",
             )
             new_promotion = resp.get_json()
             promotions.append(new_promotion)
@@ -257,7 +286,7 @@ class TestPromotionService(TestCase):
                 "is_site_wide": False,
                 "start_date": datetime(2020, 10, 14),
                 "end_date": datetime(2021, 10, 18),
-            }
+            },
         ]
         tests = [
             ("is_site_wide=true", 1),
@@ -278,21 +307,23 @@ class TestPromotionService(TestCase):
             ("active=1", 1),
             ("product=100", 3),
             ("product=200", 1),
-            ("", 4)
+            ("", 4),
         ]
         # Create the set of Promotions
         for test_case in test_cases:
             test_promotion = Promotion()
-            if not test_case['is_site_wide']:
+            if not test_case["is_site_wide"]:
                 test_promotion.products = [product_1]
-                if test_case['promo_code'] == 'XYZ0003':
+                if test_case["promo_code"] == "XYZ0003":
                     test_promotion.products.append(product_2)
 
             for attribute in test_case:
                 setattr(test_promotion, attribute, test_case[attribute])
 
             resp = self.app.post(
-                "/promotions", json=test_promotion.serialize(), content_type="application/json"
+                "/promotions",
+                json=test_promotion.serialize(),
+                content_type="application/json",
             )
         # Carry out the tests
         for query_str, length_of_result in tests:
@@ -307,14 +338,19 @@ class TestPromotionService(TestCase):
         """ Cancel a promotion """
 
         # try to cancel it before it's in there
-        resp = self.app.post('/promotions/{}/cancel'.format(1), content_type='application/json')
+        resp = self.app.post(
+            "/promotions/{}/cancel".format(1), content_type="application/json"
+        )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
         # create a new promotion
         test_promotion = self._create_promotions(1)[0]
 
         # cancel the promotion
-        resp = self.app.post('/promotions/{}/cancel'.format(test_promotion.id), content_type='application/json')
+        resp = self.app.post(
+            "/promotions/{}/cancel".format(test_promotion.id),
+            content_type="application/json",
+        )
 
         # if it gets 200 status, we pass
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
@@ -413,16 +449,20 @@ class TestPromotionService(TestCase):
                 "is_site_wide": True,
                 "start_date": datetime(2020, 9, 14),
                 "end_date": datetime(2020, 10, 15),
-            }
+            },
         ]
         tests = [
             ("100=1000&200=5000", []),
-            ("100=1000&200=5000&300=268&400=255",
+            (
+                "100=1000&200=5000&300=268&400=255",
                 [
-                    {'100':'promo_code_3'}, {'200': 'promo_code_4'},
-                    {'300': 'promo_code_2'}, {'400': 'promo_code_5'}
-                    ]),
-            ('', [])
+                    {"100": "promo_code_3"},
+                    {"200": "promo_code_4"},
+                    {"300": "promo_code_2"},
+                    {"400": "promo_code_5"},
+                ],
+            ),
+            ("", []),
         ]
         # Carry out the tests without promotions in the system
         for cart, result in tests[:1]:
@@ -432,23 +472,29 @@ class TestPromotionService(TestCase):
             self.assertEqual(data, result)
 
         # Create the set of Promotions
-        logging.debug('Creating promotions')
+        logging.debug("Creating promotions")
         for promo in promotions:
             test_promotion = PromotionFactory()
             for attribute in promo:
                 setattr(test_promotion, attribute, promo[attribute])
-            if promo['promo_code'] == 'promo_code_1':
+            if promo["promo_code"] == "promo_code_1":
                 test_promotion.products.append(product_1)
                 test_promotion.products.append(product_2)
-            elif promo['promo_code'] == 'promo_code_3':
+            elif promo["promo_code"] == "promo_code_3":
                 test_promotion.products.append(product_1)
-            elif promo['promo_code'] == 'promo_code_4':
+            elif promo["promo_code"] == "promo_code_4":
                 test_promotion.products.append(product_2)
-            elif promo['promo_code'] == 'promo_code_5':
+            elif promo["promo_code"] == "promo_code_5":
                 test_promotion.products.append(product_4)
-            logging.debug(f" Promo: {promo['promo_code']} (Promo ID: {test_promotion.id}): Products - {test_promotion.products}")
-            self.app.post("/promotions", json=test_promotion.serialize(), content_type="application/json")
-        logging.debug('Promotions created')
+            logging.debug(
+                f" Promo: {promo['promo_code']} (Promo ID: {test_promotion.id}): Products - {test_promotion.products}"
+            )
+            self.app.post(
+                "/promotions",
+                json=test_promotion.serialize(),
+                content_type="application/json",
+            )
+        logging.debug("Promotions created")
         # Carry out the tests
         for cart, result in tests[1:]:
             logging.debug(cart)
@@ -456,6 +502,7 @@ class TestPromotionService(TestCase):
             self.assertEqual(resp.status_code, status.HTTP_200_OK)
             data = resp.get_json()
             self.assertEqual(data, result)
+
 
 ######################################################################
 #   M A I N


### PR DESCRIPTION
- Added a library (freezegun) that freezes time in our testing environment so that we can test whether a promotion is active consistently
- removed back reference for product field in the promotions model because this was causing duplicate promotions to be created when we added relationships to products, this did not break any tests so I hope it is an okay change to make
- added querying by "active=0" or "active=1"
- added querying by 1 product id at a time. Decided it is not necessary to query by multiple products at once, but this might be an improvement we consider later on

Note: There are a LOT of tiny linter fixes in this PR, to filter most of them out while reviewing the PR, you can filter by which commits you see changes from and look at all but the last one. This [link](https://github.com/2020-nyu-devops/promotions/pull/67/files/c2372bbfb963193ed6bed9c14ce9d693d7cd79c3) might do that filter