### PR TITLE
Modify manifest.yml 4prod

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,18 +1,25 @@
 ---
 # This manifest deploys the Python Flask application of the promotion service with an ElephantSQL database
-applications:
-- name: nyu-promotion-service-f20
+defaults: &defaults
   path: .
   instances: 1
   memory: 128M
-  routes:
-  - route: https://nyu-promotion-service-f20.us-south.cf.appdomain.cloud/
   disk_quota: 1024M
-  buildpacks: 
-  - python_buildpack
+  buildpacks:
+    - python_buildpack
   timeout: 180
   services:
-  - ElephantSQL
+    - ElephantSQL
   env:
-    FLASK_APP : service:app
-    FLASK_DEBUG : false
+    FLASK_APP: service:app
+    FLASK_DEBUG: false
+
+applications:
+  - name: nyu-promotion-service-f20
+    <<: *defaults
+    routes:
+      - route: https://nyu-promotion-service-f20.us-south.cf.appdomain.cloud/
+  - name: nyu-promotion-service-f20-prod
+    <<: *defaults
+    routes:
+      - route: https://nyu-promotion-service-f20-prod.us-south.cf.appdomain.cloud/

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ codecov==2.1.10
 behave==1.2.6
 selenium==3.141.0
 compare==0.2b0
-requests==2.24.0
+requests==2.25.0


### PR DESCRIPTION
Here's the reference for `manifest.yml`
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#route-attribute

I also upgraded `requests` to `2.25.0` to solve the compatibility issue, because there is no easy way to downgrade `urllib3` with `python buildpacks` that we use for deployment on IBM Cloud.
![image](https://user-images.githubusercontent.com/59273037/99513341-8a5acf00-2958-11eb-838c-b6739a5ae1fa.png)
